### PR TITLE
Fix BG image title string generation

### DIFF
--- a/GustavTimer/Models/BGImageModel.swift
+++ b/GustavTimer/Models/BGImageModel.swift
@@ -18,16 +18,14 @@ struct BGImageModel: Identifiable {
     }
     
     func getTitle() -> String {
-        var result = ""
-        if !author.isEmpty {
-            result = "Image by \(author)"
+        if !author.isEmpty && !source.isEmpty {
+            return "Image by \(author) from \(source)"
+        } else if !author.isEmpty {
+            return "Image by \(author)"
+        } else if !source.isEmpty {
+            return "Image source: \(source)"
+        } else {
+            return ""
         }
-        if !source.isEmpty {
-            if result.isEmpty {
-                result = "Image source: \(source)"
-            }
-            result = result + " from \(source)"
-        }
-        return result
     }
 }


### PR DESCRIPTION
## Summary
- remove duplication in `BGImageModel.getTitle()`

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project GustavTimer.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852dc983b98832a8b6763ca395a7034