### PR TITLE
Split TimerViewModel usage

### DIFF
--- a/GustavTimer/Settings/SettingsView.swift
+++ b/GustavTimer/Settings/SettingsView.swift
@@ -14,7 +14,11 @@ import _AVKit_SwiftUI
  */
 
 struct SettingsView: View {
-    @StateObject var viewModel = TimerViewModel.shared
+    @StateObject var viewModel: SettingsViewModel
+
+    init(viewModel: SettingsViewModel = SettingsViewModel()) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
     @Environment(\.colorScheme) var colorScheme
     @State private var scrollPosition: CGFloat = 500.0
     @State private var showVideo = false
@@ -50,7 +54,7 @@ struct SettingsView: View {
                 NavigationStack {
                     List {
                         //  quickTimers
-                        MonthlyMenuItem(showVideo: $showVideo, monthlyActionText: viewModel.getChallengeText(), monthlyCounter: $viewModel.monthlyCounter)
+                        MonthlyMenuItem(showVideo: $showVideo, monthlyActionText: viewModel.getChallengeText(), monthlyCounter: $viewModel.timerViewModel.monthlyCounter)
                             .background(
                                 GeometryReader(content: { geometry in
                                     Color.clear
@@ -64,7 +68,7 @@ struct SettingsView: View {
                             )
                         
                         Section("INTERVALS") {
-                            LapsView()
+                            LapsView(viewModel: viewModel.timerViewModel)
                             if !viewModel.isTimerFull {
                                 Button(action: viewModel.addTimer, label: {
                                     Text("ADD_INTERVAL")
@@ -77,12 +81,12 @@ struct SettingsView: View {
                             Toggle("LOOP", isOn: $viewModel.isLooping)
                                 .tint(Color("StartColor"))
                             NavigationLink {
-                                SoundSelectorView(viewModel: viewModel)
+                                SoundSelectorView(viewModel: viewModel.timerViewModel)
                             } label: {
                                 ListButton(name: "Sound", value: "\(viewModel.isSoundOn ? viewModel.activeSoundTheme : "MUTE")")
                             }
                             NavigationLink {
-                                BGSelectorView(viewModel: viewModel)
+                                BGSelectorView(viewModel: viewModel.timerViewModel)
                             } label: {
                                 ListButton(name: "BACKGROUND")
                             }
@@ -240,6 +244,6 @@ struct SettingsView: View {
 
 struct EditSheetView_Previews: PreviewProvider {
     static var previews: some View {
-        SettingsView()
+        SettingsView(viewModel: SettingsViewModel())
     }
 }

--- a/GustavTimer/Settings/SettingsViewModel.swift
+++ b/GustavTimer/Settings/SettingsViewModel.swift
@@ -5,6 +5,71 @@
 //  Created by Dalibor Janeček on 26.07.2025.
 //
 
-class SettingsViewModel {
-    
+import SwiftUI
+
+class SettingsViewModel: ObservableObject {
+    @ObservedObject var timerViewModel: TimerViewModel
+
+    init(timerViewModel: TimerViewModel = .shared) {
+        self.timerViewModel = timerViewModel
+    }
+
+    // MARK: Timer settings wrappers
+    var timers: [TimerData] {
+        get { timerViewModel.timers }
+        set { timerViewModel.timers = newValue }
+    }
+
+    var isTimerFull: Bool { timerViewModel.isTimerFull }
+
+    var isLooping: Bool {
+        get { timerViewModel.isLooping }
+        set { timerViewModel.isLooping = newValue }
+    }
+
+    var showingSheet: Bool {
+        get { timerViewModel.showingSheet }
+        set { timerViewModel.showingSheet = newValue }
+    }
+
+    var showingWhatsNew: Bool {
+        get { timerViewModel.showingWhatsNew }
+        set { timerViewModel.showingWhatsNew = newValue }
+    }
+
+    var isSoundOn: Bool {
+        get { timerViewModel.isSoundOn }
+        set { timerViewModel.isSoundOn = newValue }
+    }
+
+    var activeSoundTheme: String {
+        get { timerViewModel.activeSoundTheme }
+        set { timerViewModel.activeSoundTheme = newValue }
+    }
+
+    var soundThemeArray: [String] { timerViewModel.soundThemeArray }
+
+    var bgIndex: Int {
+        get { timerViewModel.bgIndex }
+        set { timerViewModel.bgIndex = newValue }
+    }
+
+    // MARK: Wrapped methods
+    func addTimer() { timerViewModel.addTimer() }
+    func removeTimer(at offsets: IndexSet) { timerViewModel.removeTimer(at: offsets) }
+    func setBG(index: Int) { timerViewModel.setBG(index: index) }
+    func getImage() -> Image { timerViewModel.getImage() }
+    func saveSettings() { timerViewModel.saveSettings() }
+    func showWhatsNew() { timerViewModel.showWhatsNew() }
+
+    // Monthly challenge
+    var monthlyCounter: Int {
+        get { timerViewModel.monthlyCounter }
+        set { timerViewModel.monthlyCounter = newValue }
+    }
+
+    var actualMonth: Int { timerViewModel.actualMonth }
+    func getChallengeText() -> LocalizedStringKey { timerViewModel.getChallengeText() }
+    func incrementMonthlyCounter() { timerViewModel.incrementMonthlyCounter() }
 }
+

--- a/GustavTimer/SubViews/BGSelectorView.swift
+++ b/GustavTimer/SubViews/BGSelectorView.swift
@@ -14,7 +14,7 @@ struct BGSelectorView: View {
         GridItem(.adaptive(minimum: 120))
     ]
     
-    @StateObject var viewModel = TimerViewModel.shared
+    @ObservedObject var viewModel: TimerViewModel
     @Environment(\.modelContext) var context
     @Query var customImage: [CustomImageModel]
     

--- a/GustavTimer/SubViews/ControlButtonsView.swift
+++ b/GustavTimer/SubViews/ControlButtonsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ControlButtonsView: View {
-    @StateObject var viewModel = TimerViewModel.shared
+    @ObservedObject var viewModel: TimerViewModel
     @Environment(\.requestReview) var requestReview
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     
@@ -29,5 +29,5 @@ struct ControlButtonsView: View {
 }
 
 #Preview {
-    ControlButtonsView()
+    ControlButtonsView(viewModel: .shared)
 }

--- a/GustavTimer/SubViews/LapDetailView.swift
+++ b/GustavTimer/SubViews/LapDetailView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct LapDetailView: View {
     var timer: TimerData
     @Environment(\.dismiss) var dismiss
-    @StateObject var viewModel = TimerViewModel.shared
+    @ObservedObject var viewModel: TimerViewModel
     @State private var timerText: String = ""
     @State private var isShowingConfirmationDialog: Bool = false
     @FocusState private var keyboardFocused: Bool

--- a/GustavTimer/SubViews/LapsView.swift
+++ b/GustavTimer/SubViews/LapsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct LapsView: View {
-    @StateObject var viewModel = TimerViewModel.shared
+    @ObservedObject var viewModel: TimerViewModel
     @Environment(\.presentationMode) var presentationMode
     @State private var bgLapOpacity: [Int: Double] = [:] // Mapujeme indexy na opacity
     @Environment(\.colorScheme) var colorScheme
@@ -32,7 +32,7 @@ struct LapsView: View {
         ForEach(viewModel.timers.indices, id: \.self) { index in
             let timer = viewModel.timers[index]
             NavigationLink {
-                LapDetailView(timer: timer)
+                LapDetailView(timer: timer, viewModel: viewModel)
             } label: {
                 ListButton(name: timer.name, value: "\(timer.value)")
 

--- a/GustavTimer/SubViews/ProgressArrayView.swift
+++ b/GustavTimer/SubViews/ProgressArrayView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ProgressArrayView: View {
-    @StateObject var viewModel = TimerViewModel.shared
+    @ObservedObject var viewModel: TimerViewModel
     
     var body: some View {
         GeometryReader { geometry in

--- a/GustavTimer/SubViews/SoundSelectorView.swift
+++ b/GustavTimer/SubViews/SoundSelectorView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SoundSelectorView: View {
     
     var soundThemeArray = ["sound1", "sound2", "sound3", "sound4", "sound5"]
-    @StateObject var viewModel = TimerViewModel.shared
+    @ObservedObject var viewModel: TimerViewModel
     
     private let flexibleNarrowColumn = [
         GridItem(.adaptive(minimum: 120))
@@ -88,5 +88,5 @@ struct SoundSelectorView: View {
 }
 
 #Preview {
-    SoundSelectorView()
+    SoundSelectorView(viewModel: .shared)
 }

--- a/GustavTimer/Timer/TimerView.swift
+++ b/GustavTimer/Timer/TimerView.swift
@@ -23,7 +23,7 @@ struct TimerView: View {
             background
             
             VStack {
-                ProgressArrayView()
+                ProgressArrayView(viewModel: viewModel)
                     .padding(.top)
                 HStack {
                     rounds
@@ -36,7 +36,7 @@ struct TimerView: View {
                 
                 Spacer()
                 
-                ControlButtonsView()
+                ControlButtonsView(viewModel: viewModel)
             }
             .font(Font.custom("MartianMono-Regular", size: 15))
             .ignoresSafeArea(edges: .bottom)
@@ -138,7 +138,7 @@ struct TimerView: View {
         }
         .safeAreaPadding(.horizontal)
         .sheet(isPresented: $viewModel.showingSheet, content: {
-            SettingsView()
+            SettingsView(viewModel: SettingsViewModel(timerViewModel: viewModel))
         })
     }
     


### PR DESCRIPTION
## Summary
- introduce `SettingsViewModel` wrapping timer settings
- pass `TimerViewModel` and `SettingsViewModel` to views instead of using the shared instance

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68850a9fa1dc832a8f1af9124109167a